### PR TITLE
Bump LLVM version and fix aflpp version and apply patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-ARG LLVM_V=19
+ARG LLVM_V=21
 
 # Add the LLVM apt repo
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg lsb-release software-properties-common wget && \
@@ -53,9 +53,12 @@ RUN cd AFL_Runner && cargo install --path .
 RUN mkdir -p /root/.config/tmux/ && \
   echo "set -g prefix C-y" > /root/.config/tmux/tmux.conf
 
+COPY ./patches /patches
+
 # Clone AFLplusplus, build with Nyx support, and install
 ENV LLVM_CONFIG=llvm-config-${LLVM_V}
 RUN git clone https://github.com/AFLplusplus/AFLplusplus
+RUN cd AFLplusplus && git checkout v4.35c && git apply /patches/aflplusplus.patch
 RUN cd AFLplusplus/nyx_mode/ && ./build_nyx_support.sh
 RUN cd AFLplusplus && make PERFORMANCE=1 install -j$(nproc --ignore 1)
 

--- a/Dockerfile.libafl
+++ b/Dockerfile.libafl
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 # ------ Build and install dependencies ------
 
-ARG LLVM_V=19
+ARG LLVM_V=21
 
 # Add the LLVM apt repo
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg lsb-release software-properties-common wget && \
@@ -48,10 +48,13 @@ RUN rustup install nightly && rustup default nightly
 RUN cargo install cargo-afl
 RUN cargo install just
 
+COPY ./patches /patches
+
 WORKDIR /
 # Clone AFLplusplus and build
 ENV LLVM_CONFIG=llvm-config-${LLVM_V}
 RUN git clone https://github.com/AFLplusplus/AFLplusplus
+RUN cd AFLplusplus && git checkout v4.35c && git apply /patches/aflplusplus.patch
 RUN cd AFLplusplus && make PERFORMANCE=1 -j$(nproc --ignore 1)
 
 # ------ Build Bitcoin Core and the nyx agent ------

--- a/ci/libafl.justfile
+++ b/ci/libafl.justfile
@@ -4,7 +4,7 @@ compile:
 
 [working-directory: '/fuzzamoto']
 compile_nyx: compile
-	clang-19 -fPIC -DENABLE_NYX -D_GNU_SOURCE -DNO_PT_NYX ./fuzzamoto-nyx-sys/src/nyx-crash-handler.c -ldl -I. -shared -o libnyx_crash_handler.so
+	clang-21 -fPIC -DENABLE_NYX -D_GNU_SOURCE -DNO_PT_NYX ./fuzzamoto-nyx-sys/src/nyx-crash-handler.c -ldl -I. -shared -o libnyx_crash_handler.so
 	./target/release/fuzzamoto-cli init --sharedir /tmp/fuzzamoto_scenario-ir --crash-handler /fuzzamoto/libnyx_crash_handler.so --bitcoind /bitcoin/build_fuzz/bin/bitcoind --scenario ./target/release/scenario-ir --nyx-dir ./target/release/
 
 [working-directory: '/fuzzamoto']

--- a/doc/src/usage/libafl.md
+++ b/doc/src/usage/libafl.md
@@ -42,7 +42,7 @@ Then, build the crash handler and initialize the nyx share dir:
 
 ```
 # Build the crash handler
-clang-19 -fPIC -DENABLE_NYX -D_GNU_SOURCE -DNO_PT_NYX \
+clang-<version> -fPIC -DENABLE_NYX -D_GNU_SOURCE -DNO_PT_NYX \
     ./fuzzamoto-nyx-sys/src/nyx-crash-handler.c -ldl -I. -shared -o libnyx_crash_handler.so
 # Initialize the nyx share dir
 ./target/release/fuzzamoto-cli init --sharedir /tmp/fuzzamoto_scenario-ir \

--- a/patches/aflplusplus.patch
+++ b/patches/aflplusplus.patch
@@ -1,0 +1,13 @@
+diff --git a/src/afl-cc.c b/src/afl-cc.c
+index 72b94adf..f113452a 100644
+--- a/src/afl-cc.c
++++ b/src/afl-cc.c
+@@ -2139,7 +2139,7 @@ void add_sanitizers(aflcc_state_t *aflcc, char **envp) {
+ 
+         }
+ 
+-        if (!found) { insert_param(aflcc, "-flto"); }
++        // if (!found) { insert_param(aflcc, "-flto"); }
+         aflcc->have_flto = 1;
+ 
+       }


### PR DESCRIPTION
Right now, we cannot use clang-20 and future versions because AFL++ forces to add "-flto" flag when there is "-fcf-protection"
https://github.com/bitcoin/bitcoin/issues/31913#issuecomment-2674701021

we can 
1. fix the version of AFL++ that we use, and 
2. patch AFL++ before building the docker images 
to mitigate this issue.